### PR TITLE
Avoid using hash-tables in V8

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -44,10 +44,12 @@ function dispatchRequest(requestId, data) {
 	this.emit('request', data, scopedRequestFulfilled);
 }
 
-/** PrivateFunction: cleans nulls in object, preventing over-growth of the object
+/** PrivateFunction: compactObject
+ *  cleans nulls in object, preventing over-growth of  the object
  * 
  * Parameters:
- * 	(Object) object - object, from which we remove `null`, `undefined`, `''` and `false` values
+ * 	(Object) object - object, from which we remove `null`, 
+ * 	`undefined`,  `''` and `false` values
  */
 function compactObject(object) {
 	var keys = Object.keys(object);
@@ -56,7 +58,7 @@ function compactObject(object) {
         var key, datum;
         for (var i = 0, l = keys.length; i < l; i++) {
             key = keys[i];
-            datum = obj[key];
+            datum = object[key];
             if (datum) {
             	copy[key] = datum;
             }


### PR DESCRIPTION
When using `delete` objects go into slow-mode (hash tables in V8), to avoid this, we first create null references, and then create shallow copy of object to prevent endless object growth
