### PR TITLE
Fix compatibility with node-uuid@1.4.7

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -141,12 +141,13 @@ var generateGUID = function (){
 var uuidSource = fs.readFileSync(require.resolve('node-uuid'), 'utf-8');
 
 responder.source = [
-	';(function (Primus, undefined) {',
-	'if (undefined === Primus) return;',
+  'var uuid = (function () {',
+  '  var module = { exports: {} };',
   uuidSource,
-	responder.toString(),
-	'responder();',
-	'})(Primus);'
+  '  return module.exports;',
+  '})();',
+  responder.toString(),
+  'responder();'
 ].join('\n');
 
 module.exports = responder;


### PR DESCRIPTION
There have been some [breaking changes](https://github.com/broofa/node-uuid/blob/309512573ec1c60143c257157479a20f7f1f51cd/uuid.js#L272) in recent releases of `node-uuid`. As a result, this plugin [no longer works](https://github.com/primus/primus/issues/425).

This patch should fix the issue.